### PR TITLE
Sparse support for point annotator

### DIFF
--- a/pointannotator/annotate_samples.py
+++ b/pointannotator/annotate_samples.py
@@ -78,7 +78,7 @@ class AnnotateSamples:
         data : pd.DataFrame
             Tabular data.
         """
-        return data.divide(np.sum(data, axis=1)[:, None]) * 1e6
+        return data.divide(data.sum(axis=1), axis=0) * 1e6
 
     @staticmethod
     def _ranks(data):


### PR DESCRIPTION
With this PR we are adding the support for sparse data in annotator (https://github.com/biolab/point-annotator/issues/5). Now annotator accepts the sparse Pandas DataFrame too.